### PR TITLE
Change link to band website to open new tab

### DIFF
--- a/app/templates/_main_block.html
+++ b/app/templates/_main_block.html
@@ -12,7 +12,7 @@
                 </div>
             </div>
             <div class="below_video">
-                <p class="extras"><a href="{{ band.audiofile }}" alt="MP3 of {{ band.bandname }}'s performance" download>Download Audio</a> | <a href="{{ band.bandwebsite }}" alt="{{ band.bandname }}'s website">Band Website</a></p>
+                <p class="extras"><a href="{{ band.audiofile }}" alt="MP3 of {{ band.bandname }}'s performance" download>Download Audio</a> | <a href="{{ band.bandwebsite }}" alt="{{ band.bandname }}'s website" target="_blank">Band Website</a></p>
                 <ul class="list-inline social_logos">
                     <li class="share_this">Share:</li>
                     <li><a href="https://www.facebook.com/sharer.php?u={{ page_url|urlencode }}" target="_blank"><i class="icon ion-social-facebook"></i></a></li>


### PR DESCRIPTION
I was watching the Rough Francis video and clicked on the "Band Website" link and had the stream interrupted. We were already doing it for the social stuff but I guess I missed adding it to the band's website.

Also congrats on the new gig! It's a fun one!